### PR TITLE
Enemy hurt anim

### DIFF
--- a/Scenes/Enemies/DozySoldier.tscn
+++ b/Scenes/Enemies/DozySoldier.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=3 uid="uid://d06b4tntvpwmv"]
+[gd_scene load_steps=11 format=3 uid="uid://d06b4tntvpwmv"]
 
 [ext_resource type="PackedScene" uid="uid://mhpeev6v0e1o" path="res://Scenes/Enemies/Enemy.tscn" id="1_j0h6h"]
 [ext_resource type="Script" path="res://Scripts/Enemies/doze.gd" id="2_esmka"]
@@ -7,6 +7,7 @@
 [ext_resource type="Script" path="res://Scripts/Enemies/investigating.gd" id="3_w171h"]
 [ext_resource type="Script" path="res://Scripts/Enemies/chasing.gd" id="4_3jdau"]
 [ext_resource type="PackedScene" uid="uid://b7f4o17h103ph" path="res://Scenes/Components/HealthComponent.tscn" id="4_y5h1i"]
+[ext_resource type="PackedScene" uid="uid://c4qydoftxjlri" path="res://Scenes/Enemies/States/Hurting.tscn" id="8_ns8hn"]
 [ext_resource type="PackedScene" uid="uid://b8eo6b1mv3v5a" path="res://Scenes/Components/HitboxComponent.tscn" id="9_bb15j"]
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_1xcwa"]
@@ -14,10 +15,11 @@ height = 24.0
 
 [node name="DozySoldier" type="Node2D"]
 
-[node name="Enemy" parent="." node_paths=PackedStringArray("idle_state", "investigating_state", "chasing_state") instance=ExtResource("1_j0h6h")]
+[node name="Enemy" parent="." node_paths=PackedStringArray("idle_state", "investigating_state", "chasing_state", "hurting_state") instance=ExtResource("1_j0h6h")]
 idle_state = NodePath("Sleeping")
 investigating_state = NodePath("Investigating")
 chasing_state = NodePath("Chasing")
+hurting_state = NodePath("Hurting")
 original_facing_dir = 1
 weapon_scn = ExtResource("2_l6upy")
 
@@ -44,6 +46,8 @@ investigating_speed = 40.0
 [node name="Chasing" type="Node2D" parent="Enemy"]
 script = ExtResource("4_3jdau")
 chasing_speed = 60.0
+
+[node name="Hurting" parent="Enemy" instance=ExtResource("8_ns8hn")]
 
 [node name="HitboxComponent" parent="Enemy" node_paths=PackedStringArray("health_component") instance=ExtResource("9_bb15j")]
 collision_layer = 4

--- a/Scenes/Enemies/PatrollingSoldier.tscn
+++ b/Scenes/Enemies/PatrollingSoldier.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=3 uid="uid://pmnrd8y6xych"]
+[gd_scene load_steps=10 format=3 uid="uid://pmnrd8y6xych"]
 
 [ext_resource type="PackedScene" uid="uid://mhpeev6v0e1o" path="res://Scenes/Enemies/Enemy.tscn" id="1_r1qu4"]
 [ext_resource type="PackedScene" uid="uid://buaefirbgc1l" path="res://Scenes/RangedWeapon_enemy.tscn" id="2_myrgh"]
@@ -7,16 +7,18 @@
 [ext_resource type="Script" path="res://Scripts/Enemies/investigating.gd" id="4_7marf"]
 [ext_resource type="PackedScene" uid="uid://b7f4o17h103ph" path="res://Scenes/Components/HealthComponent.tscn" id="4_vp6ie"]
 [ext_resource type="Script" path="res://Scripts/Enemies/chasing.gd" id="5_tuxl7"]
+[ext_resource type="PackedScene" uid="uid://c4qydoftxjlri" path="res://Scenes/Enemies/States/Hurting.tscn" id="8_wwtt4"]
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_l6yt1"]
 height = 24.0
 
 [node name="PatrollingSoldier" type="Node2D"]
 
-[node name="Enemy" parent="." node_paths=PackedStringArray("idle_state", "investigating_state", "chasing_state") instance=ExtResource("1_r1qu4")]
+[node name="Enemy" parent="." node_paths=PackedStringArray("idle_state", "investigating_state", "chasing_state", "hurting_state") instance=ExtResource("1_r1qu4")]
 idle_state = NodePath("Patrol")
 investigating_state = NodePath("Inv")
 chasing_state = NodePath("chase")
+hurting_state = NodePath("Hurting")
 weapon_scn = ExtResource("2_myrgh")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Enemy"]
@@ -41,3 +43,5 @@ chasing_speed = 40.0
 
 [node name="Inv" type="Node2D" parent="Enemy"]
 script = ExtResource("4_7marf")
+
+[node name="Hurting" parent="Enemy" instance=ExtResource("8_wwtt4")]

--- a/Scenes/Enemies/States/Hurting.tscn
+++ b/Scenes/Enemies/States/Hurting.tscn
@@ -1,0 +1,7 @@
+[gd_scene load_steps=2 format=3 uid="uid://c4qydoftxjlri"]
+
+[ext_resource type="Script" path="res://Scripts/Enemies/hurting.gd" id="1_fxjv6"]
+
+[node name="Hurting" type="Node2D"]
+script = ExtResource("1_fxjv6")
+hurting_duration = 1.0

--- a/Scripts/Components/movement_component.gd
+++ b/Scripts/Components/movement_component.gd
@@ -9,7 +9,6 @@ var speed : float :
 var path : PackedVector2Array = [] :
 	set(value):
 		path = value
-		queue_redraw()
 
 func step(current_pos: Vector2) -> Vector2:
 	if path.is_empty():

--- a/Scripts/Enemies/enemy.gd
+++ b/Scripts/Enemies/enemy.gd
@@ -17,6 +17,7 @@ var collision : CollisionShape2D = null
 @export var idle_state : State
 @export var investigating_state: State
 @export var chasing_state: State
+@export var hurting_state: State
 
 @export_category("Facing Direction")
 enum facing {RIGHT, LEFT, DOWN, UP}
@@ -48,7 +49,8 @@ var dead: bool = false
 enum States {
 	IDLE,
 	INVESTIGATING,
-	CHASING
+	CHASING,
+	HURTING
 }
 var state : State
 # Called when the node enters the scene tree for the first time.
@@ -76,8 +78,6 @@ func _ready():
 
 func new_path():
 	movement_component.path = state.get_move_path(global_position)
-	if movement_component.path.is_empty():
-		to_idle_state()
 
 func _process(delta):
 	if paused or dead:
@@ -106,6 +106,7 @@ func on_view_exit(body: Node2D):
 	state.on_view_exit(body)
 
 func on_damage_taken(impact_dir: Vector2):
+	on_change_state(Enemy.States.HURTING)
 	AudioManager.play_effect_at(SoundEffect.SoundType.ENEMY_GETS_HURT, global_position)
 	velocity = impact_dir
 	move_and_slide()
@@ -171,6 +172,8 @@ func on_change_state(new_state: States):
 			state = investigating_state
 		States.CHASING:
 			state = chasing_state
+		States.HURTING:
+			state = hurting_state
 	connect_state_signals()
 	state.enter()
 	movement_component.path = state.get_move_path(global_position)

--- a/Scripts/Enemies/hurting.gd
+++ b/Scripts/Enemies/hurting.gd
@@ -1,0 +1,48 @@
+extends State
+
+@export var hurting_duration : float = 0.5
+
+var enemy : Enemy = null
+var target_pos : Vector2
+
+# Rethink the state machine. It may not need to have a physics process and only have a func to return the new path/target.
+func enter():
+	enemy = get_parent()
+	var tween = create_tween()
+	tween.tween_interval(hurting_duration)
+	tween.tween_callback(func(): state_change.emit(Enemy.States.INVESTIGATING))
+	target_pos = enemy.player.global_position
+	return
+
+func process(_delta: float):
+	var animation = "damaged_"
+	match enemy.facing_direction:
+		Enemy.facing.UP:
+			animation += "up"
+		Enemy.facing.DOWN:
+			animation += "down"
+		Enemy.facing.LEFT:
+			animation += "side"
+			enemy.animated_sprite.flip_h = true
+		Enemy.facing.RIGHT:
+			enemy.animated_sprite.flip_h = false
+			animation += "side"
+	enemy.animated_sprite.play(animation)
+
+func get_move_path(curr: Vector2) -> PackedVector2Array:
+	return []
+
+func exit():
+	return
+
+func on_hearing(_body: Node2D):
+	return
+
+func on_hearing_exit(_body: Node2D):
+	return
+
+func on_view(_body: Node2D):
+	return
+
+func on_view_exit(_body: Node2D):
+	return

--- a/Scripts/Enemies/hurting.gd
+++ b/Scripts/Enemies/hurting.gd
@@ -28,21 +28,3 @@ func process(_delta: float):
 			enemy.animated_sprite.flip_h = false
 			animation += "side"
 	enemy.animated_sprite.play(animation)
-
-func get_move_path(curr: Vector2) -> PackedVector2Array:
-	return []
-
-func exit():
-	return
-
-func on_hearing(_body: Node2D):
-	return
-
-func on_hearing_exit(_body: Node2D):
-	return
-
-func on_view(_body: Node2D):
-	return
-
-func on_view_exit(_body: Node2D):
-	return

--- a/Scripts/Enemies/investigating.gd
+++ b/Scripts/Enemies/investigating.gd
@@ -45,7 +45,12 @@ func process(_delta: float):
 	enemy.animated_sprite.play(animation)
 
 func get_move_path(curr: Vector2) -> PackedVector2Array:
-	return PathfindingManager.get_valid_path(curr, target)
+	var path =PathfindingManager.get_valid_path(curr, target)
+	if path.is_empty():
+		state_change.emit(Enemy.States.IDLE)
+		return []
+	else:
+		return path
 
 func exit():
 	timer.stop()

--- a/Scripts/Enemies/patrolling.gd
+++ b/Scripts/Enemies/patrolling.gd
@@ -4,9 +4,11 @@ extends State
 @export var patrolling_speed: float = 20
 ## The path to follow by the enemy
 @export var patrol_path : Path2D
+@export var recheck_time: float = 0.5
 var path_follow: PathFollow2D = null
 var progress: float = 0.0
 var enemy: Enemy
+var timer: Timer = null
 
 func enter():
 	enemy = get_parent()
@@ -18,6 +20,13 @@ func enter():
 	progress += patrolling_speed
 	path_follow.progress = progress
 	enemy.change_speed.emit(patrolling_speed)
+	if timer == null:
+		timer = Timer.new()
+		timer.one_shot = true
+		timer.wait_time = recheck_time
+		timer.autostart = false
+		add_child(timer)
+		timer.timeout.connect(should_switch_to_investigating)
 	
 func process(_delta: float):
 	AudioManager.play_effect_at(SoundEffect.SoundType.ENEMY_RUN, enemy.global_position)
@@ -36,6 +45,9 @@ func process(_delta: float):
 			animation = "walk_side"
 	enemy.animated_sprite.play(animation)
 
+func exit():
+	timer.stop()
+
 func get_move_path(curr: Vector2) -> PackedVector2Array:
 	progress += patrolling_speed
 	path_follow.progress = progress
@@ -43,13 +55,15 @@ func get_move_path(curr: Vector2) -> PackedVector2Array:
 
 func on_hearing(body: Node2D):
 	if body is Player:
-		should_switch_to_investigating(body)
-	
+		timer.start(recheck_time)
+		should_switch_to_investigating()
+
 func on_view(body: Node2D):
 	if body is Player:
 		if raycast_to_player(enemy.global_position, body.global_position, enemy.collision_mask, INF, [self]):
 			state_change.emit(Enemy.States.CHASING)
 
-func should_switch_to_investigating(player: Player):
-	if player != null and not player.is_sneaking():
+func should_switch_to_investigating():
+	timer.start(recheck_time)
+	if not enemy.player.is_sneaking():
 		state_change.emit(Enemy.States.INVESTIGATING)

--- a/Scripts/test.tscn
+++ b/Scripts/test.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=33 format=4 uid="uid://xahefqpgkdu8"]
+[gd_scene load_steps=34 format=4 uid="uid://xahefqpgkdu8"]
 
 [ext_resource type="TileSet" uid="uid://d7b6jb8080j1" path="res://Assets/Textures/Environment/Tiles/Basic/basic_wall_floor_tileset.tres" id="1_6s21k"]
 [ext_resource type="PackedScene" uid="uid://ds40r7tmgfegq" path="res://Scenes/Pickable_Item.tscn" id="2_0nvdr"]
@@ -27,6 +27,7 @@
 [ext_resource type="PackedScene" uid="uid://tb3peqakitul" path="res://Scenes/Enemies/States/Doze.tscn" id="24_0233l"]
 [ext_resource type="PackedScene" uid="uid://d2vjmgnj0nfch" path="res://Scenes/Enemies/States/Investigate.tscn" id="25_o0ic5"]
 [ext_resource type="PackedScene" uid="uid://b8eo6b1mv3v5a" path="res://Scenes/Components/HitboxComponent.tscn" id="26_vsq0v"]
+[ext_resource type="PackedScene" uid="uid://c4qydoftxjlri" path="res://Scenes/Enemies/States/Hurting.tscn" id="27_8yvbw"]
 
 [sub_resource type="Curve2D" id="Curve2D_o8ast"]
 _data = {
@@ -126,12 +127,13 @@ position = Vector2(-104, 64)
 [node name="Player" parent="." instance=ExtResource("18_wcrhm")]
 position = Vector2(188, 201)
 
-[node name="Dozy" parent="." node_paths=PackedStringArray("idle_state", "investigating_state", "chasing_state") instance=ExtResource("19_ws17x")]
+[node name="Dozy" parent="." node_paths=PackedStringArray("idle_state", "investigating_state", "chasing_state", "hurting_state") instance=ExtResource("19_ws17x")]
 position = Vector2(89, 244)
 rotation_speed = 2.0
 idle_state = NodePath("Doze")
 investigating_state = NodePath("Inv")
 chasing_state = NodePath("chase")
+hurting_state = NodePath("Hurting")
 original_facing_dir = 2
 weapon_scn = ExtResource("20_njlq3")
 
@@ -151,13 +153,15 @@ shape = SubResource("CapsuleShape2D_iyxv6")
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="Dozy"]
 sprite_frames = ExtResource("20_la463")
-animation = &"sleeping_down"
+animation = &"damaged_side"
 
 [node name="Doze" parent="Dozy" instance=ExtResource("24_0233l")]
 
 [node name="Inv" parent="Dozy" instance=ExtResource("25_o0ic5")]
 
 [node name="chase" parent="Dozy" instance=ExtResource("24_75vh8")]
+
+[node name="Hurting" parent="Dozy" instance=ExtResource("27_8yvbw")]
 
 [node name="Patrol" parent="." node_paths=PackedStringArray("idle_state", "investigating_state", "chasing_state") instance=ExtResource("19_ws17x")]
 position = Vector2(-64, 84)

--- a/Scripts/test.tscn
+++ b/Scripts/test.tscn
@@ -163,11 +163,12 @@ animation = &"damaged_side"
 
 [node name="Hurting" parent="Dozy" instance=ExtResource("27_8yvbw")]
 
-[node name="Patrol" parent="." node_paths=PackedStringArray("idle_state", "investigating_state", "chasing_state") instance=ExtResource("19_ws17x")]
+[node name="Patrol" parent="." node_paths=PackedStringArray("idle_state", "investigating_state", "chasing_state", "hurting_state") instance=ExtResource("19_ws17x")]
 position = Vector2(-64, 84)
 idle_state = NodePath("Patrol")
 investigating_state = NodePath("Inv")
 chasing_state = NodePath("chase")
+hurting_state = NodePath("Hurting")
 weapon_scn = ExtResource("20_njlq3")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Patrol"]
@@ -195,3 +196,5 @@ chasing_speed = 30.0
 patrol_path = NodePath("../../Path2D")
 
 [node name="Inv" parent="Patrol" instance=ExtResource("25_o0ic5")]
+
+[node name="Hurting" parent="Patrol" instance=ExtResource("27_8yvbw")]


### PR DESCRIPTION
Play the enemy hurt animation for 1 second (configurable). This is because the enemy hurt animation is one looping frame.
Also fixed the recheck for an enemy patrolling, now if an enemy stops sneaking while in the hearing area it will switch to investigate, though depends on the recheck time configured